### PR TITLE
fixed bug with ':' symbol

### DIFF
--- a/animelon_dl.py
+++ b/animelon_dl.py
@@ -213,6 +213,8 @@ class AnimelonDownloader():
 					the file name
 		'''
 		title = resObj["title"]
+		title = title.replace(':','')
+
 		if fileName is None:
 			fileName = os.path.join(self.savePath, title + ".mp4")
 		if (saveSubtitle):
@@ -369,6 +371,7 @@ class AnimelonDownloader():
 		if resObj is None:
 			return ()
 		title = resObj["_id"]
+		title = title.replace(':','')
 		print("Title: ", title)
 		seriesSavePath = os.path.join(self.savePath, title)
 		seasons = resObj["seasons"]


### PR DESCRIPTION
I noticed that the script wasn't working with some anime, so I decided to look into it. I found the issue. In the titles of some anime, there is a ':' character(for example "Kiseijuu: Sei no Kakuritsu (Parasyte -the maxim-)"). Since the file name is taken from the anime title, the script was trying to create a file/directory with this character in the name. This is not possible in Windows and Mac, and it's undesirable in Linux. Therefore, I made a fix that removes all ':' characters from the anime title.